### PR TITLE
feat: 購入画面からの住所変更ページ実装とバリデーション追加

### DIFF
--- a/src/app/Http/Controllers/OrderController.php
+++ b/src/app/Http/Controllers/OrderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Item;
+use App\Http\Requests\AddressRequest;
 
 class OrderController extends Controller
 {
@@ -26,5 +27,31 @@ class OrderController extends Controller
         // Order::create([...]);
 
         return redirect()->route('home')->with('success', '購入が完了しました');
+    }
+
+    public function editAddress(Request $request, $item_id)
+    {
+        $item = Item::findOrFail($item_id);
+        $user = auth()->user();
+
+        return view('orders.edit_address', compact('item', 'user'));
+    }
+
+    public function updateAddress(AddressRequest $request, $item)
+    {
+        $item = Item::findOrFail($item);
+        $user = auth()->user();
+
+        // バリデーション済みデータを取得
+        $validated = $request->validated();
+
+        // ユーザーの住所を更新
+        $user->update([
+            'postal_code' => $validated['postal_code'],
+            'address'     => $validated['address'],
+            'building'    => $validated['building'] ?? null,
+        ]);
+
+        return redirect()->route('purchase.create', ['item' => $item->id])->with('success', '住所が更新されました');
     }
 }


### PR DESCRIPTION
## 概要
購入処理に関連する住所変更機能を実装しました。

## 主な変更点
- `OrderController` に住所変更画面 (`editAddress`) と更新処理 (`updateAddress`) を追加
- バリデーション用 `AddressRequest` クラスを新規作成
  - 郵便番号：`123-4567` 形式
  - 住所：必須、255文字以内
- 住所更新後、購入画面にリダイレクト