### PR TITLE
feat: 住所変更ページとバリデーションの追加、購入画面へのリンク実装

### DIFF
--- a/src/app/Http/Controllers/OrderController.php
+++ b/src/app/Http/Controllers/OrderController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Item;
+use App\Http\Requests\AddressRequest;
 
 class OrderController extends Controller
 {
@@ -26,5 +27,31 @@ class OrderController extends Controller
         // Order::create([...]);
 
         return redirect()->route('home')->with('success', '購入が完了しました');
+    }
+
+    public function editAddress(Request $request, $item_id)
+    {
+        $item = Item::findOrFail($item_id);
+        $user = auth()->user();
+
+        return view('orders.edit_address', compact('item', 'user'));
+    }
+
+    public function updateAddress(AddressRequest $request, $item)
+    {
+        $item = Item::findOrFail($item);
+        $user = auth()->user();
+
+        // バリデーション済みデータを取得
+        $validated = $request->validated();
+
+        // ユーザーの住所を更新
+        $user->update([
+            'postal_code' => $validated['postal_code'],
+            'address'     => $validated['address'],
+            'building'    => $validated['building'] ?? null,
+        ]);
+
+        return redirect()->route('purchase.create', ['item' => $item->id])->with('success', '住所が更新されました');
     }
 }

--- a/src/app/Http/Requests/AddressRequest.php
+++ b/src/app/Http/Requests/AddressRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddressRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        // ログイン中のユーザーのみ許可
+        return auth()->check();
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'postal_code' => ['required', 'regex:/^\d{3}-\d{4}$/'], // 例: 123-4567
+            'address'     => ['required', 'string', 'max:255'],
+            'building' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'postal_code.required' => '郵便番号を入力してください。',
+            'postal_code.regex'    => '郵便番号は「123-4567」の形式で入力してください。',
+            'address.required'     => '住所を入力してください。',
+            'address.max'          => '住所は255文字以内で入力してください。',
+        ];
+    }
+}

--- a/src/public/css/edit_address.css
+++ b/src/public/css/edit_address.css
@@ -1,0 +1,69 @@
+.content {
+    max-width: 1450px;
+    margin: 60px auto;
+    text-align: center;
+}
+
+.content-title {
+    margin-bottom: 22px;
+    text-align: center;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.form-item {
+    width: 600px;
+    margin: 30px auto 5px auto;
+    font-size: 16px;
+    font-weight: bold;
+    text-align: left;
+}
+
+.form-input {
+    width: 600px;
+    height: 45px;
+    border: 1px solid #7c7c7c;
+    border-radius: 3px;
+    padding: 5px 10px;
+    font-size: 14px;
+}
+
+.form-input:focus {
+    outline: none;
+    border-color: #4A90E2;
+    box-shadow: 0 0 5px rgba(74, 144, 226, 0.5);
+}
+
+.content-error {
+    color: red;
+    font-size: 14px;
+    width: 600px;
+    margin: 0 auto 5px auto;
+    margin-bottom: 10px;
+    padding-left: 8px;
+    text-align: left;
+}
+
+.content-error ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.form-button {
+    width: 600px;
+    height: 50px;
+    background-color: #f85953;
+    color: white;
+    border: none;
+    border-radius: 5px;
+    font-size: 18px;
+    cursor: pointer;
+    margin-top: 75px;
+    margin-bottom: 30px;
+    font-weight: bolder;
+}

--- a/src/resources/views/orders/edit_address.blade.php
+++ b/src/resources/views/orders/edit_address.blade.php
@@ -1,0 +1,60 @@
+@extends('layouts.app')
+
+@section('css')
+<link rel="stylesheet" href="{{ asset('css/edit_address.css') }}">
+@endsection
+
+@section('content')
+<div class="content">
+    <h2 class="content-title">住所の変更</h2>
+
+    <form class="content-form" action="{{ route('purchase.updateAddress', ['item' => $item->id]) }}" method="POST">
+        @csrf
+        @method('PUT')
+
+        <div class="form-group">
+            <label class="form-item" for="postal_code">郵便番号</label>
+            <input class="form-input" id="postal_code" type="text" name="postal_code" value="{{ old('postal_code', $user->postal_code) }}">
+        </div>
+        @if ($errors->has('postal_code'))
+        <div class="content-error">
+            <ul>
+                @foreach ($errors->get('postal_code') as $message)
+                    <li>{{ $message }}</li>
+                @endforeach
+            </ul>
+        </div>
+        @endif
+
+        <div class="form-group">
+            <label class="form-item" for="address">住所</label>
+            <input class="form-input" id="address" type="text" name="address" value="{{ old('address', $user->address) }}">
+        </div>
+        @if ($errors->has('address'))
+        <div class="content-error">
+            <ul>
+                @foreach ($errors->get('address') as $message)
+                    <li>{{ $message }}</li>
+                @endforeach
+            </ul>
+        </div>
+        @endif
+
+        <div class="form-group">
+            <label class="form-item" for="building">建物名</label>
+            <input class="form-input" id="building" type="text" name="building" value="{{ old('building', $user->building) }}">
+        </div>
+        @if ($errors->has('building'))
+        <div class="content-error">
+            <ul>
+                @foreach ($errors->get('building') as $message)
+                    <li>{{ $message }}</li>
+                @endforeach
+            </ul>
+        </div>
+        @endif
+
+        <button class="form-button" type="submit">変更する</button>
+    </form>
+</div>
+@endsection

--- a/src/resources/views/orders/purchase.blade.php
+++ b/src/resources/views/orders/purchase.blade.php
@@ -34,7 +34,7 @@
         <div class="purchase__delivery">
             <div class="purchase__delivery-row">
                 <h3 class="purchase__delivery-title">配送先</h3>
-                <a class="purchase__delivery-link" href="">変更する</a>
+                <a class="purchase__delivery-link" href="{{ route('purchase.editAddress', ['item' => $item->id]) }}">変更する</a>
             </div>
             <div class="purchase__delivery-content">
                 <p class="purchase__delivery-text"><span>〒</span>{{ $user->postal_code }}</p>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -34,6 +34,8 @@ Route::middleware('auth')->group(function () {
         Route::get('/{item}', [OrderController::class, 'create'])->name('purchase.create');
         Route::post('/{item}', [OrderController::class, 'store'])->name('purchase.store');
         Route::get('/address/{item}', [OrderController::class, 'editAddress'])->name('purchase.editAddress');
-        Route::post('/address/{item}', [OrderController::class, 'updateAddress'])->name('purchase.updateAddress');
+        Route::put('/address/{item}', [OrderController::class, 'updateAddress'])->name('purchase.updateAddress');
     });
+
+    // その他の認証が必要なルートをここに追加
 });


### PR DESCRIPTION
## 概要
購入処理に関連する住所登録・変更機能を実装しました。
前回の PR で戻した後、修正版として再提出します。

## 主な変更点
- `OrderController` に住所変更画面 (`editAddress`) と更新処理 (`updateAddress`) を追加
- バリデーション用 `AddressRequest` クラスを新規作成
  - 郵便番号：`123-4567` 形式
  - 住所：必須、255文字以内
- 住所変更画面のビュー `edit_address.blade.php` と CSS `edit_address.css` を追加
- 住所更新後、購入画面にリダイレクト