### PR TITLE
fix: 商品詳細ビューのレイアウト修正・カテゴリー最大3件表示

### DIFF
--- a/src/public/css/items/show.css
+++ b/src/public/css/items/show.css
@@ -14,7 +14,6 @@
     height: 500px;
     margin: 60px;
     margin-top: 30px;
-    background: #CCC;
 }
 
 .item-img img {
@@ -128,6 +127,27 @@
     line-break: anywhere;
 }
 
+.category :first-child {
+    margin-left: 3.5em;
+}
+
+.category-name {
+    background: #ddd;
+    border: 2px solid #ddd;
+    font-size: 13px;
+    border-radius: 30px;
+    margin-right: 10px;
+    margin-bottom: 13px;
+    padding: 2px 13px;
+}
+
+.condition-name {
+    font-size: 14px;
+    margin-left: 3.5em;
+    margin-bottom: 13px;
+    padding: 2px 13px;
+}
+
 .comment-title {
     color: #696969;
 }
@@ -140,9 +160,8 @@
 }
 
 .user-img {
-    background: #ddd;
-    width: 65px;
-    height: 65px;
+    width: 75px;
+    height: 75px;
     border-radius: 40px;
 }
 

--- a/src/resources/views/items/show.blade.php
+++ b/src/resources/views/items/show.blade.php
@@ -50,7 +50,9 @@
             <h3 class="detail-title">商品の情報</h3>
             <p class="category">
                 カテゴリー
-                <span class="category-name">{{ $item->categories->first()->name ?? '未設定' }}</span>
+                @foreach($item->categories as $category)
+                <span class="category-name">{{ $category->name }}</span>
+                @endforeach
             </p>
             <p class="condition">
                 商品の状態
@@ -62,7 +64,7 @@
             <div class="comment-list">
                 @foreach($item->comments as $comment)
                 <div class="comment-item">
-                    <img class="user-img" src="{{ asset('images/default_icon.png') }}" alt="" >
+                    <img class="user-img" src="{{ $comment->user->profile_image_url ?? asset('images/default_icon.png') }}" alt="{{ $comment->user->name }}">
                     <p class="user-name">{{ $comment->user->name }}:</p>
                     <p class="comment-text">{{ $comment->content }}</p>
                 </div>


### PR DESCRIPTION
- items/show.blade.php のレイアウトを調整
- 商品詳細ページでカテゴリーを最大3件まで表示するよう修正
- 見た目の崩れを改善