### PR TITLE
feat: プロフィール編集・購入処理のバリデーション追加およびFortify初回ログイン処理の改善

### DIFF
--- a/src/app/Actions/Fortify/CreateNewUser.php
+++ b/src/app/Actions/Fortify/CreateNewUser.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use App\Http\Requests\RegisterRequest;
+use Illuminate\Support\Facades\Session;
 
 class CreateNewUser implements CreatesNewUsers
 {
@@ -17,10 +18,14 @@ class CreateNewUser implements CreatesNewUsers
         $request->merge($input);
         $request->validateResolved();
 
-        return User::create([
+        $user = User::create([
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => Hash::make($input['password']),
         ]);
+
+        Session::put('just_registered', true);
+
+        return $user;
     }
 }

--- a/src/app/Http/Controllers/OrderController.php
+++ b/src/app/Http/Controllers/OrderController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Item;
 use App\Models\Order;
 use App\Http\Requests\AddressRequest;
+use App\Http\Requests\PurchaseRequest;
 
 class OrderController extends Controller
 {
@@ -19,19 +20,20 @@ class OrderController extends Controller
         return view('orders.purchase', compact('item', 'user', 'payment'));
     }
 
-    public function store(Request $request, $item_id)
+    public function store(PurchaseRequest $request, $item_id)
     {
         $item = Item::findOrFail($item_id);
         $user = auth()->user();
 
-        // フォーム名 payment に合わせる
-        $paymentMethod = $request->input('payment', 'convenience_store');
+        // バリデーション済みデータを取得
+        $validated = $request->validated();
 
         // 注文登録
         Order::create([
             'user_id' => $user->id,
             'item_id' => $item->id,
-            'payment_method' => $paymentMethod,
+            'payment_method' => $validated['payment'],
+            'address' => $validated['address'],
         ]);
 
         // 商品が購入済みならフラグ更新

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\User;
 use Illuminate\Http\Request;
+use App\Http\Requests\ProfileRequest;
 
 class UserController extends Controller
 {
@@ -22,17 +23,12 @@ class UserController extends Controller
         return view('mypage.edit', compact('user'));
     }
 
-    public function update(Request $request)
+    public function update(ProfileRequest $request)
     {
         $user = $request->user();
 
-        $validated = $request->validate([
-            'name' => 'required|string|max:255',
-            'postal_code' => 'nullable|string|max:255',
-            'address' => 'nullable|string|max:255',
-            'building' => 'nullable|string|max:255',
-            'profile_image' => 'nullable|image|max:1024',
-        ]);
+        // バリデーション済みデータを取得
+        $validated = $request->validated();
 
         if ($request->hasFile('profile_image')) {
             $validated['profile_image'] = $request->file('profile_image')
@@ -42,6 +38,6 @@ class UserController extends Controller
         $user->update($validated);
 
         return redirect()->route('mypage.show')
-                        ->with('status', 'プロフィールを更新した');
+                            ->with('status', 'プロフィールを更新しました。');
     }
 }

--- a/src/app/Http/Requests/AddressRequest.php
+++ b/src/app/Http/Requests/AddressRequest.php
@@ -26,8 +26,8 @@ class AddressRequest extends FormRequest
     {
         return [
             'postal_code' => ['required', 'regex:/^\d{3}-\d{4}$/'], // 例: 123-4567
-            'address'     => ['required', 'string', 'max:255'],
-            'building' => ['nullable', 'string', 'max:255'],
+            'address'     => 'required|string|max:255',
+            'building' => 'nullable|string|max:255',
         ];
     }
 
@@ -35,7 +35,7 @@ class AddressRequest extends FormRequest
     {
         return [
             'postal_code.required' => '郵便番号を入力してください。',
-            'postal_code.regex'    => '郵便番号は「123-4567」の形式で入力してください。',
+            'postal_code.regex'    => '郵便番号はハイフンありで8文字にしてください。',
             'address.required'     => '住所を入力してください。',
             'address.max'          => '住所は255文字以内で入力してください。',
         ];

--- a/src/app/Http/Requests/CommentRequest.php
+++ b/src/app/Http/Requests/CommentRequest.php
@@ -14,14 +14,14 @@ class CommentRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'content' => ['required', 'max:255'],
+            'content' => 'required|max:255',
         ];
     }
 
     public function messages(): array
     {
         return [
-            'content.required' => 'コメントは必須です。',
+            'content.required' => 'コメントを入力してください。',
             'content.max' => 'コメントは255文字以内で入力してください。',
         ];
     }

--- a/src/app/Http/Requests/ExhibitionRequest.php
+++ b/src/app/Http/Requests/ExhibitionRequest.php
@@ -25,7 +25,7 @@ class ExhibitionRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'description' => 'required|string|max:500',
+            'description' => 'required|string|max:255',
             'image' => 'required|image|mimes:jpeg,png|max:1024',
             'category_id' => 'required|array|min:1|max:3',
             'category_id.*' => 'exists:categories,id',
@@ -38,16 +38,16 @@ class ExhibitionRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'name.required' => '商品名は必須です。',
-            'description.required' => '商品説明は必須です。',
-            'image.required' => '商品画像は必須です。',
+            'name.required' => '商品名を入力してください。',
+            'description.required' => '商品説明を入力してください。',
+            'image.required' => '商品画像を入力してください。',
             'image.image' => '画像ファイルである必要があります。',
             'image.mimes' => 'JPEGまたはPNG形式の画像を選択してください。',
-            'category_id.required' => 'カテゴリーは必須です。',
+            'category_id.required' => 'カテゴリーを入力してください。',
             'category_id.*.exists' => '選択されたカテゴリーは存在しません。',
             'category_id.max' => 'カテゴリーは最大3つまで選択できます。',
-            'condition.required' => '商品の状態は必須です。',
-            'price.required' => '価格は必須です。',
+            'condition.required' => '商品の状態を入力してください。',
+            'price.required' => '価格を入力してください。',
             'price.numeric' => '価格は数値で入力してください。',
             'price.min' => '価格は0円以上にしてください。',
         ];

--- a/src/app/Http/Requests/ProfileRequest.php
+++ b/src/app/Http/Requests/ProfileRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ProfileRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+
+        return [
+            'profile_image' => 'nullable|image|mimes:jpeg,png',
+            'name' => 'required|string|max:20',
+            'postal_code' => ['required', 'regex:/^\d{3}-\d{4}$/'],
+            'address' => 'required|string',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'profile_image.image' => 'プロフィール画像は画像ファイルにしてください。',
+            'profile_image.mimes' => 'プロフィール画像はJPEGまたはPNG形式でアップロードしてください。',
+            'name.required' => 'ユーザー名を入力してください。',
+            'name.max' => 'ユーザー名は20文字以内で入力してください。',
+            'postal_code.required' => '郵便番号を入力してください。',
+            'postal_code.regex' => '郵便番号はハイフンありで8文字にしてください。',
+            'address.required' => '住所を入力してください。',
+        ];
+    }
+}

--- a/src/app/Http/Requests/PurchaseRequest.php
+++ b/src/app/Http/Requests/PurchaseRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PurchaseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'payment' => 'required',
+            'address' => 'required',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'payment.required' => '支払い方法を選択してください。',
+            'address.required' => '配送先を選択してください。',
+        ];
+    }
+}

--- a/src/app/Http/Responses/LoginResponse.php
+++ b/src/app/Http/Responses/LoginResponse.php
@@ -10,11 +10,13 @@ class LoginResponse implements LoginResponseContract
     {
         $user = $request->user();
 
-        if ($user->is_first_login) {
-            $user->update(['is_first_login' => false]);
+        $request->session()->forget('url.intended');
 
+        if (session('just_registered')) {
+            session()->forget('just_registered');
             return redirect()->route('mypage.edit');
         }
+
 
         return redirect()->route('home');
     }

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -23,7 +23,6 @@ class CreateUsersTable extends Migration
             $table->string('address')->nullable();
             $table->string('building')->nullable();
             $table->string('profile_image')->nullable();
-            $table->boolean('is_first_login')->default(true);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/src/public/css/mypage/show.css
+++ b/src/public/css/mypage/show.css
@@ -1,3 +1,9 @@
+.alert-success {
+    color: rgb(255, 80, 74);
+    border-bottom: 1px solid rgb(255, 80, 74);
+    padding: 10px 15px;
+}
+
 .content {
     max-width: 1450px;
     margin: 50px auto;

--- a/src/public/css/orders/purchase.css
+++ b/src/public/css/orders/purchase.css
@@ -8,6 +8,22 @@
     gap: 20px;
 }
 
+.alert-success {
+    color: rgb(255, 80, 74);
+    border-bottom: 1px solid rgb(255, 80, 74);
+    padding: 10px 15px;
+}
+
+.alert-error {
+    color: rgb(255, 80, 74);
+    border-bottom: 1px solid rgb(255, 80, 74);
+    padding: 10px 15px;
+}
+
+.alert-error__list {
+    list-style: none;
+}
+
 .purchase__group {
     width: 60%;
     margin-bottom: 15px;
@@ -16,7 +32,6 @@
 
 .purchase__item {
     display: flex;
-    align-items: center;
     gap: 50px;
     padding-bottom: 25px;
     margin-bottom: 25px;

--- a/src/resources/views/mypage/show.blade.php
+++ b/src/resources/views/mypage/show.blade.php
@@ -5,6 +5,11 @@
 @endsection
 
 @section('content')
+@if(session('status'))
+    <div class="alert alert-success">
+        {{ session('status') }}
+    </div>
+@endif
 <div class="content">
     <div class="profile-group">
         <div class="profile-icon">

--- a/src/resources/views/orders/purchase.blade.php
+++ b/src/resources/views/orders/purchase.blade.php
@@ -5,6 +5,21 @@
 @endsection
 
 @section('content')
+@if(session('success'))
+    <div class="alert-success">
+        {{ session('success') }}
+    </div>
+@endif
+@if($errors->any())
+    <div class="alert-error">
+        <ul class="alert-error__list">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
 <div class="purchase__content">
     <div class="purchase__group">
         <div class="purchase__item">
@@ -68,6 +83,7 @@
         <form action="{{ route('purchase.store', $item->id) }}" method="POST">
             @csrf
             <input type="hidden" name="payment" value="{{ $payment }}">
+            <input type="hidden" name="address" value="{{ $user->address }}">
             <button class="purchase__summary-button" type="submit">購入する</button>
         </form>
     </div>


### PR DESCRIPTION
- プロフィール編集フォームに FormRequest（ProfileRequest）を適用
- 購入処理に FormRequest（PurchaseRequest）を適用
- 既存フォームリクエスト（住所・コメント・出品）のバリデーションルールを整理
- UserController・OrderController のバリデーション処理をリファクタリング
- Fortify の初回ログイン処理を Session 管理に変更（is_first_login カラム削除）
- Fortify 関連クラス（CreateNewUser・LoginResponse）の処理を整理