### PR TITLE
fix: UserFactory.php から is_first_login カラムを削除

### DIFF
--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -22,7 +22,6 @@ class UserFactory extends Factory
             'address' => $this->faker->address(),
             'building' => $this->faker->optional()->secondaryAddress(),
             'profile_image' => $this->faker->imageUrl(200, 200, 'people', true),
-            'is_first_login' => true,
             'remember_token' => Str::random(10),
         ];
     }


### PR DESCRIPTION
### 修正内容
- UserFactory から 'is_first_login' カラムを削除
- これにより、migrate:fresh --seed 実行時のカラム未存在エラーを解消
