### PR TITLE
feat: 商品ダミーデータのSeeder追加と画像表示処理の統一

### DIFF
--- a/src/database/factories/CommentFactory.php
+++ b/src/database/factories/CommentFactory.php
@@ -11,8 +11,6 @@ class CommentFactory extends Factory
     public function definition()
     {
         return [
-            'user_id' => User::factory(),
-            'item_id' => Item::factory(),
             'content' => $this->faker->sentence(10),
         ];
     }

--- a/src/database/factories/ItemFactory.php
+++ b/src/database/factories/ItemFactory.php
@@ -10,7 +10,6 @@ class ItemFactory extends Factory
     public function definition()
     {
         return [
-            'user_id' => User::factory(),
             'name' => $this->faker->words(3, true),
             'description' => $this->faker->paragraph(),
             'condition' => $this->faker->randomElement(['良好', '目立った傷や汚れなし', 'やや傷や汚れあり', '状態が悪い']),

--- a/src/database/migrations/2025_09_05_034425_create_items_table.php
+++ b/src/database/migrations/2025_09_05_034425_create_items_table.php
@@ -14,7 +14,8 @@ class CreateItemsTable extends Migration
     public function up()
     {
         Schema::create('items', function (Blueprint $table) {
-            $table->id();$table->unsignedBigInteger('user_id');
+            $table->id();
+            $table->unsignedBigInteger('user_id');
             $table->foreign('user_id')
                     ->references('id')
                     ->on('users')

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -15,18 +15,8 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             CategoriesTableSeeder::class,
+            UserSeeder::class,
+            ItemSeeder::class,
         ]);
-
-        if (app()->environment(['local', 'testing'])) {
-            \App\Models\User::factory(5)->create()->each(function ($user) {
-                $items = \App\Models\Item::factory(2)->create(['user_id' => $user->id]);
-                foreach ($items as $item) {
-                    \App\Models\Comment::factory(2)->create([
-                        'user_id' => $user->id,
-                        'item_id' => $item->id,
-                    ]);
-                }
-            });
-        }
     }
 }

--- a/src/database/seeders/ItemSeeder.php
+++ b/src/database/seeders/ItemSeeder.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Item;
+
+class ItemSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Item::create([
+            'user_id' => 1,
+            'name' => '腕時計',
+            'description' => 'スタイリッシュなデザインのメンズ腕時計',
+            'price' => 15000,
+            'condition' => '良好',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Armani+Mens+Clock.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 1,
+            'name' => 'HDD',
+            'description' => '高速で信頼性の高いハードディスク',
+            'price' => 5000,
+            'condition' => '目立った傷や汚れなし',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/HDD+Hard+Disk.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 1,
+            'name' => '玉ねぎ3束',
+            'description' => '新鮮な玉ねぎ3束のセット',
+            'price' => 300,
+            'condition' => 'やや傷や汚れあり',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/iLoveIMG+d.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 1,
+            'name' => '革靴',
+            'description' => 'クラシックなデザインの革靴',
+            'price' => 4000,
+            'condition' => '状態が悪い',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Leather+Shoes+Product+Photo.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 1,
+            'name' => 'ノートPC',
+            'description' => '高性能なノートパソコン',
+            'price' => 45000,
+            'condition' => '良好',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Living+Room+Laptop.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 2,
+            'name' => 'マイク',
+            'description' => '高音質のレコーディング用マイク',
+            'price' => 8000,
+            'condition' => '目立った傷や汚れなし',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Music+Mic+4632231.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 2,
+            'name' => 'ショルダーバッグ',
+            'description' => 'おしゃれなショルダーバッグ',
+            'price' => 3500,
+            'condition' => 'やや傷や汚れあり',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Purse+fashion+pocket.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 2,
+            'name' => 'タンブラー',
+            'description' => '使いやすいタンブラー',
+            'price' => 500,
+            'condition' => '状態が悪い',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Tumbler+souvenir.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 2,
+            'name' => 'コーヒーミル',
+            'description' => '手動のコーヒーミル',
+            'price' => 4000,
+            'condition' => '良好',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Waitress+with+Coffee+Grinder.jpg',
+        ]);
+
+        Item::create([
+            'user_id' => 2,
+            'name' => 'メイクセット',
+            'description' => '便利なメイクアップセット',
+            'price' => 2500,
+            'condition' => '目立った傷や汚れなし',
+            'image' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/%E5%A4%96%E5%87%BA%E3%83%A1%E3%82%A4%E3%82%AF%E3%82%A2%E3%83%83%E3%83%95%E3%82%9A%E3%82%BB%E3%83%83%E3%83%88.jpg',
+        ]);
+    }
+}

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        User::factory()->create([
+            'name' => 'ダミーユーザー1',
+            'email' => 'dummy1@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+        User::factory()->create([
+            'name' => 'ダミーユーザー2',
+            'email' => 'dummy2@example.com',
+            'password' => Hash::make('password'),
+        ]);
+
+
+        User::factory()->create([
+            'name' => 'ダミーユーザー3',
+            'email' => 'dummy3@example.com',
+            'password' => Hash::make('password'),
+        ]);
+    }
+}

--- a/src/resources/views/items/index.blade.php
+++ b/src/resources/views/items/index.blade.php
@@ -28,9 +28,15 @@
             @else
                 <div class="product-list">
                     @foreach($items as $item)
+                        @php
+                            $img = $item->image;
+                            $src = $img
+                                ? (filter_var($img, FILTER_VALIDATE_URL) ? $img : asset('storage/' . $img))
+                                : asset('images/no_image.png');
+                        @endphp
                         <div class="product-item">
                             <a href="{{ route('items.show', $item->id) }}">
-                                <img class="product-img" src="{{ asset('storage/' . $item->image) }}" alt="{{ $item->name }}">
+                                <img class="product-img" src="{{ $src }}" alt="{{ $item->name }}">
                                 <p class="product-name">{{ $item->name }}</p>
                             </a>
                             @if($item->isSold())
@@ -46,9 +52,15 @@
     @else
         <div class="product-list">
             @foreach ($items as $item)
+                @php
+                    $img = $item->image;
+                    $src = $img
+                        ? (filter_var($img, FILTER_VALIDATE_URL) ? $img : asset('storage/' . $img))
+                        : asset('images/no_image.png');
+                @endphp
                 <div class="product-item">
                     <a href="{{ route('items.show', $item->id) }}">
-                        <img class="product-img" src="{{ asset('storage/' . $item->image) }}" alt="{{ $item->name }}">
+                        <img class="product-img" src="{{ $src }}" alt="{{ $item->name }}">
                         <p class="product-name">{{ $item->name }}</p>
                     </a>
                     @if($item->isSold())

--- a/src/resources/views/items/show.blade.php
+++ b/src/resources/views/items/show.blade.php
@@ -7,7 +7,14 @@
 @section('content')
 <div class="item-container">
     <div class="item-img">
-        <img src="{{ $item->image ? asset('storage/' . $item->image) : asset('images/no_image.png') }}" alt="{{ $item->name }}">
+        @php
+            $img = $item->image;
+            $src = $img
+                ? (filter_var($img, FILTER_VALIDATE_URL) ? $img : asset('storage/' . $img))
+                : asset('images/no_image.png');
+        @endphp
+        <img src="{{ $src }}" alt="{{ $item->name }}">
+
         @if($item->isSold())
             <span class="sold-label">Sold</span>
         @endif
@@ -15,7 +22,7 @@
     <div class="item-content">
         <div class="item-info">
             <h1 class="item-title">{{ $item->name }}</h1>
-            <p class="brand-title">{{ $item->description }}</p>
+            <p class="brand-title">{{ $item->brand }}</p>
             <p class="item-price">
                 <span>¥</span>{{ number_format($item->price) }}<span>(税込)</span>
             </p>

--- a/src/resources/views/mypage/show.blade.php
+++ b/src/resources/views/mypage/show.blade.php
@@ -56,6 +56,14 @@
     </div>
 
     <div class="content-item">
+        @php
+            $imageSrc = function ($img) {
+                if (! $img) return asset('images/no_image.png');
+                return filter_var($img, FILTER_VALIDATE_URL)
+                    ? $img : asset('storage/' . $img);
+            };
+        @endphp
+
         @if($page == 'sell')
             <div class="product-list">
                 @forelse($listedItems as $item)
@@ -66,7 +74,7 @@
                         @if($transaction)
                             <!-- 取引あり：取引詳細へ -->
                             <a href="{{ route('transactions.show', $transaction->id) }}">
-                                <img class="product-img" src="{{ $item->image ? asset('storage/' . e($item->image)) : asset('images/no_image.png') }}" alt="{{ $item->name }}">
+                                <img class="product-img" src="{{ $imageSrc($item->image) }}" alt="{{ $item->name }}">
                                 <p class="product-name">{{ $item->name }}</p>
                             </a>
 
@@ -78,7 +86,7 @@
                         @else
                             <!-- 取引なし：商品詳細へ -->
                             <a href="{{ route('items.show', $item->id) }}">
-                                <img class="product-img" src="{{ $item->image ? asset('storage/' . e($item->image)) : asset('images/no_image.png') }}" alt="{{ $item->name }}">
+                                <img class="product-img" src="{{ $imageSrc($item->image) }}" alt="{{ $item->name }}">
                                 <p class="product-name">{{ $item->name }}</p>
                             </a>
                         @endif
@@ -93,8 +101,8 @@
                 @php $item = $transaction->item; @endphp
                     <div class="product-item">
                         <a href="{{ route('transactions.show', $transaction->id) }}">
-                            <img class="product-img" src="{{ $item->image ? asset('storage/' . e($item->image)) : asset('images/no_image.png') }}" alt="{{ $item->name }}">
-                            <p class="product-name">{{ $item->name }}</p>
+                            <img class="product-img" src="{{ $imageSrc($item?->image) }}" alt="{{ $item?->name ?? '（商品なし）' }}">
+                            <p class="product-name">{{ $item?->name ?? '（商品なし）' }}</p>
                         </a>
                         <span class="sold-label">Sold</span>
                     </div>
@@ -108,8 +116,8 @@
                     @php $item = $transaction->item; @endphp
                     <div class="product-item">
                         <a href="{{ route('transactions.show', $transaction->id) }}">
-                            <img class="product-img" src="{{ $item->image ? asset('storage/' . e($item->image)) : asset('images/no_image.png') }}" alt="{{ $item->name }}">
-                            <p class="product-name">{{ $item->name }}</p>
+                            <img class="product-img" src="{{ $imageSrc($item?->image) }}" alt="{{ $item?->name ?? '（商品なし）' }}">
+                            <p class="product-name">{{ $item?->name ?? '（商品なし）' }}</p>
                             @if(($transaction->unread_count ?? 0) > 0)
                                 <span class="unread-badge">{{ $transaction->unread_count }}</span>
                             @endif

--- a/src/resources/views/orders/purchase.blade.php
+++ b/src/resources/views/orders/purchase.blade.php
@@ -24,7 +24,13 @@
     <div class="purchase__group">
         <div class="purchase__item">
             <div class="purchase__item-img">
-                <img src="{{ $item->image ? asset('storage/' . $item->image) : asset('images/no_image.png') }}" alt="{{ $item->name }}">
+                @php
+                    $img = $item->image;
+                    $src = $img
+                        ? (filter_var($img, FILTER_VALIDATE_URL) ? $img : asset('storage/' . $img))
+                        : asset('images/no_image.png');
+                @endphp
+                <img src="{{ $src }}" alt="{{ $item->name }}">
             </div>
             <div class="purchase__item-info">
                 <h2 class="purchase__item-title">{{ $item->name }}</h2>

--- a/src/resources/views/transactions/show.blade.php
+++ b/src/resources/views/transactions/show.blade.php
@@ -47,7 +47,12 @@
 
         <div class="content-info">
             <div class="content-info__img">
-                <img src="{{ $transactionItem->image ? asset('storage/' . $transactionItem->image) : asset('images/no_image.png') }}" alt="{{ $transactionItem->name }}">
+                @php
+                    $img = $transactionItem->image ?? null;
+                    $src = $img ? (filter_var($img, FILTER_VALIDATE_URL) ? $img : asset('storage/' . $img))
+                                : asset('images/no_image.png');
+                @endphp
+                <img src="{{ $src }}" alt="{{ $transactionItem->name }}">
             </div>
             <div class="content-info__details">
                 <h3 class="content-info__title">{{ $transactionItem->name }}</h3>


### PR DESCRIPTION
## 概要
フリマアプリにおける商品データのダミー作成要件に対応するため、ユーザー・商品データの Seeder を新規追加しました。  
あわせて、商品画像の表示処理を見直し、「URL画像」「storage保存画像」「未設定時」のすべてに対応できるよう各画面を修正しています。

## 主な変更内容
- 商品ダミーデータ（10件）を登録する ItemSeeder を新規追加
- ダミーユーザー（3件）を登録する UserSeeder を新規追加  
  - ユーザー1：商品5件  
  - ユーザー2：商品5件  
  - ユーザー3：商品なし
- DatabaseSeeder を修正し、固定ダミーデータのみ投入する構成に変更
- 商品画像表示を以下の条件で統一
  - URL の場合：そのまま表示
  - storage パスの場合：`storage/` 経由で表示
  - 未設定の場合：`no_image.png` を表示
- 商品一覧・商品詳細・マイページ・購入画面・取引画面の画像表示処理を共通方針に修正
- 商品詳細画面において、誤って description を表示していたブランド表記を修正
- Factory（Item / Comment）を Seeder 運用に合わせて調整
- items テーブルマイグレーションの軽微な整形（改行のみ）