### PR TITLE
fix: レビュー機能からコメント項目を削除

### DIFF
--- a/src/app/Http/Controllers/ReviewController.php
+++ b/src/app/Http/Controllers/ReviewController.php
@@ -6,7 +6,6 @@ use App\Http\Requests\ReviewRequest;
 use App\Models\Review;
 use App\Models\Transaction;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\DB;
 
 class ReviewController extends Controller
 {
@@ -48,7 +47,6 @@ class ReviewController extends Controller
             'reviewer_id'    => $userId,
             'reviewee_id'    => $revieweeId,
             'rating'         => $validated['rating'],
-            'comment'        => $validated['comment'] ?? null,
         ]);
 
         return redirect()

--- a/src/app/Http/Requests/ReviewRequest.php
+++ b/src/app/Http/Requests/ReviewRequest.php
@@ -25,7 +25,6 @@ class ReviewRequest extends FormRequest
     {
         return [
             'rating'  => 'required|integer|between:1,5',
-            'comment' => 'nullable|string|max:1000',
         ];
     }
 }

--- a/src/app/Models/Review.php
+++ b/src/app/Models/Review.php
@@ -14,7 +14,6 @@ class Review extends Model
         'reviewer_id',
         'reviewee_id',
         'rating',
-        'comment',
     ];
 
     public function transaction()

--- a/src/database/migrations/2026_01_18_220030_create_reviews_table.php
+++ b/src/database/migrations/2026_01_18_220030_create_reviews_table.php
@@ -19,7 +19,6 @@ class CreateReviewsTable extends Migration
             $table->foreignId('reviewer_id')->constrained('users')->cascadeOnDelete();
             $table->foreignId('reviewee_id')->constrained('users')->cascadeOnDelete();
             $table->tinyInteger('rating')->unsigned();
-            $table->text('comment')->nullable();
             $table->timestamps();
             $table->unique(['transaction_id', 'reviewer_id']);
         });


### PR DESCRIPTION
## 概要
取引完了後のユーザー評価機能について、要件に含まれていない項目を削除し、仕様通りに修正しました。

## 主な変更内容
- 評価機能からコメント項目を削除し、評価（★）のみに統一
- ReviewRequest のバリデーションを評価値（1〜5）のみに修正
- ReviewController からコメント保存処理を削除
- reviews テーブル定義から comment カラムを削除
- モデル・コントローラ・マイグレーションの整合性を調整